### PR TITLE
Added index.js file to let webpack properly find the library

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+export * from './dist/sugar';


### PR DESCRIPTION
Added `index.js` file to let webpack properly find the library.
This is fix for an error that is appearing when actually trying to use Sugar:
`Module not found: Error: Can't resolve 'sugar'` 